### PR TITLE
Add -s flag to save/recover state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.egg
 .tox
 cover
+.cplay.rec

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@
 	- removed cplay.list
 	- added support for VLC
 	- added support for playing videos
+	- added -s flag to allow saving state on close and restoring on open
 	- translations are now managed on
 	  https://www.transifex.com/projects/p/cplay-ng/
 	- a lot of internal restructuring to ease collaboration with Andreas van

--- a/cplay.1
+++ b/cplay.1
@@ -61,6 +61,10 @@ Start in \fIrandom\fP mode.
 .IP
 Switch mixer channels.
 .HP
+\fB\-s\fR, \fB\-\-save
+.IP
+Save state on close and restore on open.
+.HP
 \fB\-\-fifo \fIFIFO
 .IP
 FIFO socket used by \fIcnq\fP

--- a/cplay/cplay.py
+++ b/cplay/cplay.py
@@ -55,7 +55,6 @@ gettext.install('cplay', resource_filename(__name__, 'i18n'))
 XTERM = re.search('rxvt|xterm', os.environ.get('TERM', ''))
 MACRO = {}
 APP = None
-RECOVERY_FILE = '.cplay.rec'
 
 
 class Application(object):
@@ -174,7 +173,7 @@ class Application(object):
             data['offset'] = backend.offset
             data['length'] = backend.length
 
-        with open(RECOVERY_FILE, 'wb') as fh:
+        with open(self.recover, 'wb') as fh:
             pickle.dump(data, fh)
 
     def quit(self, status=0):
@@ -2035,7 +2034,8 @@ def parse_args():
                         help=_('Switch mixer channels.'))
     parser.add_argument('-V', '--video', action='store_true',
                         help=_('Allow to play videos.'))
-    parser.add_argument('-s', '--save', action='store_true',
+    parser.add_argument('-s', '--save',
+                        nargs='?', default=False, metavar='FILE',
                         help=_('Save state on close and restore on open.'))
     parser.add_argument('--fifo', help=_('FIFO socket used by cnq'))
     parser.add_argument('files', metavar=_('file'), nargs='*',
@@ -2043,8 +2043,11 @@ def parse_args():
 
     args = parser.parse_args()
 
-    if args.save and os.path.exists(RECOVERY_FILE):
-        with open(RECOVERY_FILE, 'rb') as fh:
+    if not args.save and args.save is not False:
+        args.save = '.cplay.rec'
+
+    if args.save and os.path.exists(args.save):
+        with open(args.save, 'rb') as fh:
             recovery = pickle.load(fh)
     else:
         recovery = {}

--- a/cplay/cplay.py
+++ b/cplay/cplay.py
@@ -174,7 +174,7 @@ class Application(object):
             data['offset'] = backend.offset
             data['length'] = backend.length
 
-        with open(RECOVERY_FILE, 'w') as fh:
+        with open(RECOVERY_FILE, 'wb') as fh:
             pickle.dump(data, fh)
 
     def quit(self, status=0):
@@ -2044,7 +2044,7 @@ def parse_args():
     args = parser.parse_args()
 
     if args.save and os.path.exists(RECOVERY_FILE):
-        with open(RECOVERY_FILE) as fh:
+        with open(RECOVERY_FILE, 'rb') as fh:
             recovery = pickle.load(fh)
     else:
         recovery = {}


### PR DESCRIPTION
This adds a flag `-s`/`--save` that causes cplay to dump its state to a file on close and recover that state on open. The following state is saved:
- playlist
- random
- repeat
- currently played track
- position within track

The state is saved in a file called `.cplay.rec` in the current directory. This means that there is one separate state for each directory.
